### PR TITLE
Fixed SetNuiFocus conflicts when focus hasn't previously been set

### DIFF
--- a/src/NUI/ElsUiPanel.cs
+++ b/src/NUI/ElsUiPanel.cs
@@ -64,7 +64,8 @@ namespace ELS.NUI
         {
             Utils.DebugWriteLine("Disabling Ui");
             API.SendNuiMessage("{\"type\":\"enableui\", \"enable\":false}");
-            API.SetNuiFocus(false, false);
+            if (_enabled == 2)
+                API.SetNuiFocus(false, false);
             _enabled = 0;
         }
 
@@ -74,7 +75,8 @@ namespace ELS.NUI
         {
             Utils.DebugWriteLine("Showing Ui");
             API.SendNuiMessage("{\"type\":\"enableui\", \"enable\":true}");
-            API.SetNuiFocus(false, false);
+            if (_enabled == 2)
+                API.SetNuiFocus(false, false);
             _enabled = 1;
         }
 


### PR DESCRIPTION
Caused issues when having chat open and getting out of a vehicle. You would end up with the chat window being left open and being unable to type in it.

This has been resolved by ensuring we only remove NUI focus if it has been set to start with.